### PR TITLE
add ability to enter cube by colors

### DIFF
--- a/lib/rubiks_cube.rb
+++ b/lib/rubiks_cube.rb
@@ -1,5 +1,6 @@
 require 'rubiks_cube/version'
 require 'rubiks_cube/cube'
+require 'rubiks_cube/colors'
 require 'rubiks_cube/cubie'
 require 'rubiks_cube/algorithms'
 require 'rubiks_cube/solution'

--- a/lib/rubiks_cube/colors.rb
+++ b/lib/rubiks_cube/colors.rb
@@ -1,0 +1,109 @@
+module RubiksCube
+  class Colors
+    DIRECTIONS = %i{up front right back left down}
+
+    # Return a RubiksCube::Cube given colors for each face.
+    # Each face is a list of three rows (top to bottom). Each row contains three
+    # characters for the colors of the face (left to right). Rows are separated
+    # by commas and faces are separated by semicolons. The faces
+    # are in the order up, front, right, back, left, and down.
+    # For example, a solved cube might be created by:
+    # BBB,BBB,BBB;WWW,WWW,WWW;RRR,RRR,RRR;YYY,YYY,YYY;OOO,OOO,OOO;GGG,GGG,GGG
+    def self.by_face(colors)
+      Cube.new Colors.new(colors).to_state
+    end
+
+    attr_reader :colors
+
+    def initialize(colors)
+      @colors = colors
+    end
+
+    def to_h
+      @hash ||= Hash[DIRECTIONS.zip(cells_by_line_by_face)]
+    end
+
+    def cells_by_line_by_face
+      lines_by_face.map { |face| face.map { |line| line_to_array(line) } }
+    end
+
+    def line_to_array(line)
+      if line.length != 3
+        raise "#{line} is not three characters"
+      end
+      line.split('')
+    end
+
+    def lines_by_face
+      faces.map { |face| face_to_array(face) }
+    end
+
+    def face_to_array(face)
+      array = face.split(',')
+      if array.length != 3
+        raise "#{face} is not three rows"
+      end
+      array
+    end
+
+    def faces
+      array = colors.split(';')
+      if array.length != 6
+        raise "number of faces is not six"
+      end
+      array
+    end
+
+    def color_to_face
+      @color_to_face ||= DIRECTIONS.each_with_object({}) do |direction, hash|
+        center = to_h[direction][1][1] 
+        if hash[center]
+          raise "#{center} is listed in the center twice"
+        end
+        hash[center] = direction.to_s[0].upcase
+      end
+    end
+
+    def to_face(color)
+      color_to_face[color] or raise "#{color} is not listed in the center anywhere"
+    end
+
+    def to_state
+      [
+        # edges, top tier
+        [[:up, 2, 1], [:front, 0, 1]],
+        [[:up, 1, 2], [:right, 0, 1]],
+        [[:up, 0, 1], [:back, 0, 1]],
+        [[:up, 1, 0], [:left, 0, 1]],
+
+        # edges, middle tier
+        [[:front, 1, 0], [:left, 1, 2]],
+        [[:front, 1, 2], [:right, 1, 0]],
+        [[:back, 1, 0], [:right, 1, 2]],
+        [[:back, 1, 2], [:left, 1, 0]],
+
+        # edges, bottom tier
+        [[:down, 0, 1], [:front, 2, 1]],
+        [[:down, 1, 2], [:right, 2, 1]],
+        [[:down, 2, 1], [:back, 2, 1]],
+        [[:down, 1, 0], [:left, 2, 1]],
+
+        # corners, top tier
+        [[:up, 2, 0], [:front, 0, 0], [:left, 0, 2]],
+        [[:up, 2, 2], [:right, 0, 0], [:front, 0, 2]],
+        [[:up, 0, 2], [:back, 0, 0], [:right, 0, 2]],
+        [[:up, 0, 0], [:left, 0, 0], [:back, 0, 2]],
+
+        # corners, bottom tier
+        [[:down, 0, 0], [:left, 2, 2], [:front, 2, 0]],
+        [[:down, 0, 2], [:front, 2, 2], [:right, 2, 0]],
+        [[:down, 2, 2], [:right, 2, 2], [:back, 2, 0]],
+        [[:down, 2, 0], [:back, 2, 2], [:left, 2, 0]]
+      ].map do |cubelet|
+        cubelet.map do |face, row, column|
+          to_face(to_h[face][row][column])
+        end.join('')
+      end.join(' ')
+    end
+  end
+end

--- a/spec/rubiks_cube/colors_spec.rb
+++ b/spec/rubiks_cube/colors_spec.rb
@@ -1,0 +1,160 @@
+#encoding: utf-8
+require 'spec_helper'
+
+describe RubiksCube::Colors do
+  describe '.by_face' do
+    # U;F;R;B;L;D
+
+    subject { described_class.by_face colors }
+
+    context 'for a solved cube' do
+      let(:colors) {
+        'BBB,BBB,BBB;WWW,WWW,WWW;RRR,RRR,RRR;YYY,YYY,YYY;OOO,OOO,OOO;GGG,GGG,GGG'
+      }
+
+      it "reads it in" do
+        expect(subject).to be_solved
+        expect(subject.state).to eq(
+          "UF UR UB UL FL FR BR BL DF DR DB DL UFL URF UBR ULB DLF DFR DRB DBL"
+        )
+      end
+    end
+
+    context 'for an example with a few scrambled faces' do
+      let(:colors) {
+        'RRR,RRG,RYG;GGY,GGR,GGG;RRY,YYY,YYY;WWW,WWW,WWB;BBB,BBB,OBB;OOO,OOO,WOO'
+      }
+
+      it "comes up with the right state" do
+        expect(subject.state).to eq(
+          "RF FU UB UL FL UR BR BL DF DR DB DL UFL FUR UBR ULB DLF DFR DRB BLD"
+        )
+      end
+    end
+
+    context 'when the number of squares in a row is not 3' do
+      let(:colors) {
+        'RRR,RRG,RYG;GGY,GR,GGG;RRY,YYY,YYY;WWW,WWW,WWB;BBB,BBB,OBB;OOO,OOO,WOO'
+      }
+
+      it 'throws an exception' do
+        expect {
+          subject
+        }.to raise_error('GR is not three characters')
+      end
+    end
+
+    context 'when the number of rows is not 3' do
+      let(:colors) {
+        'RRR,RRG,RYG;GGY,GGR,GGG,OOO;RRY,YYY,YYY;WWW,WWW,WWB;BBB,BBB,OBB;OOO,OOO,WOO'
+      }
+
+      it 'throws an exception' do
+        expect {
+          subject
+        }.to raise_error('GGY,GGR,GGG,OOO is not three rows')
+      end
+    end
+
+    context 'when the number of faces is not 6' do
+      let(:colors) {
+        'RRR,RRG,RYG;GGY,GGR,GGG;WWW,WWW,WWB;BBB,BBB,OBB;OOO,OOO,WOO'
+      }
+
+      it 'throws an exception' do
+        expect {
+          subject
+        }.to raise_error('number of faces is not six')
+      end
+    end
+
+    context 'two center faces are identical' do
+      let(:colors) {
+        'BBB,BBB,BBB;WWW,WBW,WWW;RRR,RRR,RRR;YYY,YYY,YYY;OOO,OOO,OOO;GGG,GGG,GGG'
+      }
+
+      it 'throws an exception' do
+        expect {
+          subject
+        }.to raise_error('B is listed in the center twice')
+      end
+    end
+
+    context 'with a color not in a center face' do
+      let(:colors) {
+        'PBB,BBB,BBB;WWW,WWW,WWW;RRR,RRR,RRR;YYY,YYY,YYY;OOO,OOO,OOO;GGG,GGG,GGG'
+      }
+
+      it 'throws an exception' do
+        expect {
+          subject
+        }.to raise_error('P is not listed in the center anywhere')
+      end
+    end
+  end
+
+  describe "#to_h" do
+    subject { RubiksCube::Colors.new(colors).to_h }
+    context 'with a bunch of values' do
+      # Of course, a real cube wouldn't have 54 colors like this, but this is easier
+      # for testing #to_h
+      let(:colors) {
+        'abc,def,ghi;ABC,DEF,GHI;αβγ,δεζ,ηθἱ;БГД,ЖИЛ,ПҀȢ;jkl,mno,pqr;ΓΔΘ,ΞΣΦ,ΨΩΛ'
+      }
+
+      it "lets you get them" do
+        expect(subject[:up][0]).to eq(['a', 'b', 'c'])
+        expect(subject[:up][1]).to eq(['d', 'e', 'f'])
+        expect(subject[:up][2]).to eq(['g', 'h', 'i'])
+
+        expect(subject[:front][0]).to eq(['A', 'B', 'C'])
+
+        expect([:right, :back, :left, :down].map { |direction| subject[direction][0][0] }).
+          to eq(['α', 'Б', 'j', 'Γ'])
+      end
+
+    end
+
+  end
+
+  describe "#color_to_face" do
+    subject { RubiksCube::Colors.new(colors).color_to_face }
+    let(:colors) {
+      'RRR,RRG,RYG;GGY,GGR,GGG;RRY,YYY,YYY;WWW,WWW,WWB;BBB,BBB,WBB;OOO,OOO,OOW'
+    }
+    it "should map from a color to the face" do
+      expect(subject).to eq({'R' => 'U', 'G' => 'F', 'Y' => 'R',
+        'W' => 'B', 'B' => 'L', 'O' => 'D'})
+    end 
+  end
+
+  describe "#to_face" do
+    subject { RubiksCube::Colors.new(colors) }
+    let(:colors) {
+      'RRR,RRG,RYG;GGY,GGR,GGG;RRY,YYY,YYY;WWW,WWW,WWB;BBB,BBB,WBB;OOO,OOO,OOW'
+    }
+
+    it "can tell you which face a given color is on" do
+      expect(subject.to_face 'R').to eq('U')
+      expect(subject.to_face 'G').to eq('F')
+      expect(subject.to_face 'Y').to eq('R')
+    end
+  end
+
+  describe "#to_state" do
+    subject { RubiksCube::Colors.new(colors).to_state }
+
+    context 'for a slightly scrambled example' do
+      let(:colors) {
+        'RRR,RRG,RYG;GGY,GGR,GGG;RRY,YYY,YYY;WWW,WWW,WWB;BBB,BBB,OBB;OOO,OOO,WOO'
+      }
+
+      it "comes up with the right state" do
+        expect(subject).to eq(
+          "RF FU UB UL FL UR BR BL DF DR DB DL UFL FUR UBR ULB DLF DFR DRB BLD"
+        )
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Although relative notation (up, front, etc) is obviously best for many purposes, it might not be the easiest way to enter the state of a cube (especially for people new to this stuff). Here's a class which lets you read off the colors of your cube and construct a Cube object from that (then you can get out everything the usual notation).

There's a bit of documentation in a comment at the top of the source, although the ideal documentation would have some drawings showing what order the faces are supposed to be listed.
